### PR TITLE
Fixed log over-nullification and created a dummy log_hexdump function

### DIFF
--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -7,6 +7,9 @@
 #ifndef ZEPHYR_INCLUDE_LOGGING_LOG_H_
 #define ZEPHYR_INCLUDE_LOGGING_LOG_H_
 
+#include <logging/log_instance.h>
+#include <logging/log_core.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -25,7 +28,7 @@ extern "C" {
  * @{
  */
 
-#if defined(__JETBRAINS_IDE__) || defined(__clang__) || 1
+#if defined(__JETBRAINS_IDE__) || defined(__clang__)
 
 /* This include is kept to mimic behavior between IDE and "normal" build */
 #include <zephyr.h>
@@ -69,18 +72,7 @@ static inline char *log_strdup(const char *str)
 	return 0;
 }
 
-#define _LOG_MODULE_DATA_CREATE(_name, _level)
-
-#define LOG_MODULE_REGISTER(...)	;
-
-#define LOG_MODULE_DECLARE(...)		;
-
-#define LOG_LEVEL_SET(level)		(0)
-
 #else /* defined(__CLION_IDE__) || defined(PARASOFT) */
-
-#include <logging/log_instance.h>
-#include <logging/log_core.h>
 
 /**
  * @brief Writes an ERROR level message to the log.
@@ -350,6 +342,8 @@ static inline char *log_strdup(const char *str)
 	return z_log_strdup(str);
 }
 
+#endif /* defined(__CLION_IDE__) || defined(PARASOFT) */
+
 #ifdef __cplusplus
 }
 #define LOG_IN_CPLUSPLUS 1
@@ -493,7 +487,6 @@ static inline char *log_strdup(const char *str)
 #define LOG_LEVEL_SET(level) static const uint32_t __log_level __unused = \
 				Z_LOG_RESOLVED_LEVEL(level, 0)
 
-#endif /* defined(__CLION_IDE__) || defined(PARASOFT) */
 /**
  * @}
  */

--- a/include/logging/log.h
+++ b/include/logging/log.h
@@ -36,6 +36,12 @@ static inline void log_noop(char *fmt, ...)
 
 }
 
+static inline void log_hexdump_noop(const void * data, size_t length,
+	const char * str)
+{
+
+}
+
 #define LOG_DBG(...)	log_noop(__VA_ARGS__)
 
 #define LOG_INF(...)	log_noop(__VA_ARGS__)
@@ -46,13 +52,17 @@ static inline void log_noop(char *fmt, ...)
 
 #define LOG_PRINTK(...)	log_noop(__VA_ARGS__)
 
-#define LOG_HEXDUMP_ERR(_data, _length, _str)	log_noop("")
+#define LOG_HEXDUMP_ERR(_data, _length, _str)\
+			log_hexdump_noop(_data, _length, _str)
 
-#define LOG_HEXDUMP_WRN(_data, _length, _str)	log_noop("")
+#define LOG_HEXDUMP_WRN(_data, _length, _str)\
+			log_hexdump_noop(_data, _length, _str)
 
-#define LOG_HEXDUMP_INF(_data, _length, _str)	log_noop("")
+#define LOG_HEXDUMP_INF(_data, _length, _str)\
+			log_hexdump_noop(_data, _length, _str)
 
-#define LOG_HEXDUMP_DBG(_data, _length, _str)	log_noop("")
+#define LOG_HEXDUMP_DBG(_data, _length, _str)\
+			log_hexdump_noop(_data, _length, _str)
 
 static inline char *log_strdup(const char *str)
 {


### PR DESCRIPTION
The current log.h file cause the formatter to behave strangely and, most important, it nullifies the logger even in the final build.